### PR TITLE
Add order line items, customer name on addresses

### DIFF
--- a/Block/Onepage/Success.php
+++ b/Block/Onepage/Success.php
@@ -134,14 +134,135 @@ class Success extends Template
 
     public function getBillingDetails()
     {
+        $billingAddress = $this->order->getBillingAddress();
+        if (!$billingAddress) {
+            return [];
+        }
         return [
-            'company' => $this->order->getBillingAddress()->getCompany(),
-            'street' => $this->order->getBillingAddress()->getStreet(),
-            'city' => $this->order->getBillingAddress()->getCity(),
-            'region' => $this->order->getBillingAddress()->getRegion(),
-            'postcode' => $this->order->getBillingAddress()->getPostcode(),
-            'countryId' => $this->order->getBillingAddress()->getCountryId()
+            'customerName' => trim($billingAddress->getFirstname() . ' ' . $billingAddress->getLastname()),
+            'company' => $billingAddress->getCompany(),
+            'street' => $billingAddress->getStreet(),
+            'city' => $billingAddress->getCity(),
+            'region' => $billingAddress->getRegion(),
+            'postcode' => $billingAddress->getPostcode(),
+            'countryId' => $billingAddress->getCountryId()
         ];
+    }
+
+    /**
+     * Get formatted line item data for each item in the order.
+     *
+     * Configurable parents (e.g. configurable, bundle) are returned with their
+     * children excluded so each visible row reflects what the customer sees in cart.
+     *
+     * @return array
+     */
+    public function getOrderItemsDetails()
+    {
+        $items = [];
+        $orderItems = $this->order->getAllVisibleItems();
+        if (!$orderItems) {
+            return $items;
+        }
+
+        $currencySymbol = $this->currency->getCurrency($this->order->getOrderCurrencyCode())->getSymbol();
+
+        foreach ($orderItems as $orderItem) {
+            $qty = (float)$orderItem->getQtyOrdered();
+            $rowTotal = (float)$orderItem->getRowTotalInclTax();
+            if (!$rowTotal) {
+                $rowTotal = (float)$orderItem->getRowTotal();
+            }
+            $price = (float)$orderItem->getPriceInclTax();
+            if (!$price) {
+                $price = (float)$orderItem->getPrice();
+            }
+
+            $items[] = [
+                'name' => $orderItem->getName(),
+                'sku' => $orderItem->getSku(),
+                'qty' => $qty,
+                'qtyFormatted' => rtrim(rtrim(number_format($qty, 2, '.', ''), '0'), '.'),
+                'price' => $currencySymbol . number_format($price, 2),
+                'rowTotal' => $currencySymbol . number_format($rowTotal, 2),
+                'image' => $this->getOrderItemImage($orderItem),
+                'options' => $this->getOrderItemOptions($orderItem),
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Get the configured image URL for an order line item.
+     *
+     * @param \Magento\Sales\Api\Data\OrderItemInterface $orderItem
+     * @return string
+     */
+    public function getOrderItemImage($orderItem)
+    {
+        try {
+            $product = $this->productRepository->get($orderItem->getSku());
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return '';
+        }
+
+        $imageType = $this->getOrderItemsImageType();
+        $imagePath = $product->getImage($imageType);
+        if (!$imagePath || $imagePath === 'no_selection') {
+            $imagePath = $product->getImage('image');
+        }
+        if (!$imagePath || $imagePath === 'no_selection') {
+            return '';
+        }
+
+        return $this->mediaConfig->getBaseMediaUrl() . $imagePath;
+    }
+
+    /**
+     * Configurable image type for line items, defaults to small_image.
+     *
+     * @return string
+     */
+    public function getOrderItemsImageType()
+    {
+        $type = $this->getConfigValue('line_items_row', 'image_type');
+        return $type ?: 'small_image';
+    }
+
+    /**
+     * Custom options / configurable selections in label => value form.
+     *
+     * @param \Magento\Sales\Api\Data\OrderItemInterface $orderItem
+     * @return array
+     */
+    public function getOrderItemOptions($orderItem)
+    {
+        $options = [];
+        $productOptions = $orderItem->getProductOptions();
+        if (!is_array($productOptions)) {
+            return $options;
+        }
+
+        if (!empty($productOptions['attributes_info'])) {
+            foreach ($productOptions['attributes_info'] as $attribute) {
+                $options[] = [
+                    'label' => $attribute['label'] ?? '',
+                    'value' => $attribute['value'] ?? '',
+                ];
+            }
+        }
+
+        if (!empty($productOptions['options'])) {
+            foreach ($productOptions['options'] as $option) {
+                $options[] = [
+                    'label' => $option['label'] ?? '',
+                    'value' => $option['value'] ?? '',
+                ];
+            }
+        }
+
+        return $options;
     }
 
     public function getRelatedProductIdsOfOrderItems()

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -63,6 +63,35 @@
                     </depends>
                 </field>
             </group>
+            <group id="line_items_row" translate="label" type="text" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Order Line Items Row</label>
+                <field id="enable" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Show Order Line Items</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Displays a list of purchased products with image, name, price and quantity</comment>
+                </field>
+                <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Row Title</label>
+                    <comment>Optional heading shown above the line items. Leave empty to hide.</comment>
+                    <depends>
+                        <field id="enable">1</field>
+                    </depends>
+                </field>
+                <field id="image_type" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Line Item Image Type</label>
+                    <source_model>Zero1\ImprovedCheckoutSuccessPageHyva\Model\Source\Image</source_model>
+                    <depends>
+                        <field id="enable">1</field>
+                    </depends>
+                </field>
+                <field id="show_subtotal" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Show Line Item Subtotal</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enable">1</field>
+                    </depends>
+                </field>
+            </group>
             <group id="cms_static_block_row" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>CMS Static Block Row</label>
                 <field id="enable" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,6 +11,12 @@
                 <enable_shipping_information>1</enable_shipping_information>
                 <enable_billing_information>1</enable_billing_information>
             </order_information_row>
+            <line_items_row>
+                <enable>0</enable>
+                <title>Items in your order</title>
+                <image_type>small_image</image_type>
+                <show_subtotal>1</show_subtotal>
+            </line_items_row>
             <cms_static_block_row>
                 <enable>0</enable>
             </cms_static_block_row>

--- a/view/frontend/templates/success.phtml
+++ b/view/frontend/templates/success.phtml
@@ -26,6 +26,9 @@
                 <?php if (!empty($shippingDetails)) : ?>
                     <div class="card w-full shipping">
                         <h3 class="font-bold mb-2 text-2xl"><?php echo __('Shipping Details'); ?></h3>
+                        <?php if (!empty($shippingDetails['customerName'])) : ?>
+                            <p><?php echo $block->escapeHtml($shippingDetails['customerName']); ?></p>
+                        <?php endif; ?>
                         <?php if (!empty($shippingDetails['company'])) : ?>
                             <p><?php echo $block->escapeHtml($shippingDetails['company']); ?></p>
                         <?php endif; ?>
@@ -60,6 +63,9 @@
                 <?php $billingDetails = $block->getBillingDetails(); ?>
                 <div class="card w-full billing">
                     <h3 class="font-bold mb-2 text-2xl"><?php echo __('Billing Details'); ?></h3>
+                    <?php if (!empty($billingDetails['customerName'])) : ?>
+                        <p><?php echo $block->escapeHtml($billingDetails['customerName']); ?></p>
+                    <?php endif; ?>
                     <?php if (!empty($billingDetails['company'])) : ?>
                         <p><?php echo $block->escapeHtml($billingDetails['company']); ?></p>
                     <?php endif; ?>
@@ -81,6 +87,70 @@
                 </div>
             <?php endif; ?>
         </div>
+    <?php endif; ?>
+
+    <?php if ($block->getConfigFlag('line_items_row', 'enable') === true) : ?>
+        <?php $orderItems = $block->getOrderItemsDetails(); ?>
+        <?php if (count($orderItems) > 0) : ?>
+            <div class="card mb-8 line-items">
+                <?php if ($block->getConfigValue('line_items_row', 'title')) : ?>
+                    <h3 class="font-bold mb-4 text-2xl">
+                        <?php echo $block->escapeHtml($block->getConfigValue('line_items_row', 'title')); ?>
+                    </h3>
+                <?php endif; ?>
+                <?php foreach ($orderItems as $orderItem) : ?>
+                    <div class="flex gap-4 py-4 border-b last:border-b-0 border-gray-200">
+                        <?php if (!empty($orderItem['image'])) : ?>
+                            <div class="line-item-image shrink-0" style="width:88px;">
+                                <img class="h-auto"
+                                     style="width:88px;height:auto;"
+                                     width="88"
+                                     src="<?php echo $block->escapeUrl($orderItem['image']); ?>"
+                                     alt="<?php echo $block->escapeHtmlAttr($orderItem['name']); ?>"
+                                     loading="lazy" />
+                            </div>
+                        <?php endif; ?>
+                        <div class="line-item-details flex-1 flex flex-col sm:flex-row sm:items-start gap-2">
+                            <div class="line-item-info flex-1">
+                                <p class="font-semibold"><?php echo $block->escapeHtml($orderItem['name']); ?></p>
+                                <?php if (!empty($orderItem['sku'])) : ?>
+                                    <p class="text-sm">
+                                        <?php echo __('SKU'); ?>: <?php echo $block->escapeHtml($orderItem['sku']); ?>
+                                    </p>
+                                <?php endif; ?>
+                                <?php if (!empty($orderItem['options'])) : ?>
+                                    <dl class="text-sm mt-1">
+                                        <?php foreach ($orderItem['options'] as $option) : ?>
+                                            <?php if (empty($option['label'])) { continue; } ?>
+                                            <div class="flex gap-1">
+                                                <dt class="font-medium"><?php echo $block->escapeHtml($option['label']); ?>:</dt>
+                                                <dd><?php echo $block->escapeHtml($option['value']); ?></dd>
+                                            </div>
+                                        <?php endforeach; ?>
+                                    </dl>
+                                <?php endif; ?>
+                            </div>
+                            <div class="line-item-pricing shrink-0 text-left sm:text-right whitespace-nowrap">
+                                <p>
+                                    <span class="font-medium"><?php echo __('Price'); ?>:</span>
+                                    <span><?php echo $block->escapeHtml($orderItem['price']); ?></span>
+                                </p>
+                                <p>
+                                    <span class="font-medium"><?php echo __('Qty'); ?>:</span>
+                                    <span><?php echo $block->escapeHtml($orderItem['qtyFormatted']); ?></span>
+                                </p>
+                                <?php if ($block->getConfigFlag('line_items_row', 'show_subtotal') === true) : ?>
+                                    <p>
+                                        <span class="font-medium"><?php echo __('Subtotal'); ?>:</span>
+                                        <span class="font-semibold"><?php echo $block->escapeHtml($orderItem['rowTotal']); ?></span>
+                                    </p>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
     <?php endif; ?>
 
     <?php if ($block->getStaticBlockToRender() !== null) : ?>


### PR DESCRIPTION
## Added
- Order line items section showing image, name, SKU, options, price, qty, subtotal — disabled by default; enable under Stores → Configuration → Sales → Improved Success Page → Order Line Items Row
- Customer name displayed at the top of the Shipping Details and Billing Details cards
- Defensive null-guard for billing address (matches the 1.0.6 fix that was applied to shipping)

## Config
New group `improved_checkout_success_page/line_items_row` with: `enable`, `title`, `image_type`, `show_subtotal`
